### PR TITLE
Developer Experience

### DIFF
--- a/.docker/Dockerfile.gin
+++ b/.docker/Dockerfile.gin
@@ -1,0 +1,15 @@
+# BASE IMAGES
+FROM golang:1.21 as go-base
+
+FROM go-base as go-builder
+
+WORKDIR /app
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+RUN go install github.com/codegangsta/gin@latest
+
+CMD [ "make", "start" ]

--- a/.docker/Dockerfile.tailwindcss
+++ b/.docker/Dockerfile.tailwindcss
@@ -1,0 +1,18 @@
+# BASE IMAGES
+FROM node:20.7.0-bullseye as node-base
+
+FROM node-base as css-watcher
+
+WORKDIR /app
+
+COPY package.json .
+COPY package-lock.json .
+
+RUN npm install --prefer-offline
+
+COPY Makefile .
+COPY tailwind.config.js .
+COPY web/templ web/templ
+COPY web/static web/static
+
+CMD [ "make", "css" ]

--- a/.docker/Dockerfile.tailwindcss
+++ b/.docker/Dockerfile.tailwindcss
@@ -11,8 +11,5 @@ COPY package-lock.json .
 RUN npm install --prefer-offline
 
 COPY Makefile .
-COPY tailwind.config.js .
-COPY web/templ web/templ
-COPY web/static web/static
 
 CMD [ "make", "css" ]

--- a/.docker/Dockerfile.templ
+++ b/.docker/Dockerfile.templ
@@ -1,0 +1,13 @@
+# BASE IMAGES
+FROM golang:1.21 as go-base
+
+FROM go-base as templ-watcher
+
+WORKDIR /app
+
+COPY go.mod .
+COPY Makefile .
+
+RUN go install github.com/a-h/templ/cmd/templ@$(go list -m -f '{{ .Version }}' github.com/a-h/templ)
+
+CMD [ "make", "templ" ]

--- a/.docker/Dockerfile.templ
+++ b/.docker/Dockerfile.templ
@@ -8,6 +8,6 @@ WORKDIR /app
 COPY go.mod .
 COPY Makefile .
 
-RUN go install github.com/a-h/templ/cmd/templ@$(go list -m -f '{{ .Version }}' github.com/a-h/templ)
+RUN make install-templ
 
 CMD [ "make", "templ" ]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+/.docker/
 /.git/
 /.github/
 /.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,7 @@
     "esbenp.prettier-vscode",
     "golang.go",
     "a-h.templ",
-    "redhat.vscode-yaml",
-    "me-dutour-mathieu.vscode-github-actions",
+    "github.vscode-github-actions",
     "ms-azuretools.vscode-docker",
     "formulahendry.auto-rename-tag",
     "yzhang.markdown-all-in-one"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,14 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "compose",
+      "type": "shell",
+      "command": "docker compose up",
+      "presentation": {
+        "panel": "dedicated"
+      }
+    },
+    {
       "label": "start",
       "dependsOrder": "parallel",
       "dependsOn": ["templ", "css", "app"]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,6 +8,35 @@
       "presentation": {
         "panel": "dedicated"
       }
+    },
+    {
+      "label": "start",
+      "dependsOrder": "parallel",
+      "dependsOn": ["templ", "css", "app"]
+    },
+    {
+      "label": "app",
+      "type": "shell",
+      "command": "make start",
+      "presentation": {
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "templ",
+      "type": "shell",
+      "command": "make templ",
+      "presentation": {
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "css",
+      "type": "shell",
+      "command": "make css",
+      "presentation": {
+        "panel": "dedicated"
+      }
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,35 +8,6 @@
       "presentation": {
         "panel": "dedicated"
       }
-    },
-    {
-      "label": "start",
-      "dependsOrder": "parallel",
-      "dependsOn": ["templ", "css", "app"]
-    },
-    {
-      "label": "app",
-      "type": "shell",
-      "command": "make start",
-      "presentation": {
-        "panel": "dedicated"
-      }
-    },
-    {
-      "label": "templ",
-      "type": "shell",
-      "command": "make templ",
-      "presentation": {
-        "panel": "dedicated"
-      }
-    },
-    {
-      "label": "css",
-      "type": "shell",
-      "command": "make css",
-      "presentation": {
-        "panel": "dedicated"
-      }
     }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ FROM go-base as templ-builder
 WORKDIR /app
 
 COPY go.mod .
-RUN go install github.com/a-h/templ/cmd/templ@$(go list -m -f '{{ .Version }}' github.com/a-h/templ)
+COPY Makefile .
+RUN make install-templ
 
 COPY web/templ web/templ
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ FROM go-base as templ-builder
 
 WORKDIR /app
 
-RUN go install github.com/a-h/templ/cmd/templ@latest
+COPY go.mod .
+RUN go install github.com/a-h/templ/cmd/templ@$(go list -m -f '{{ .Version }}' github.com/a-h/templ)
 
 COPY web/templ web/templ
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 start:
-	gin run start
+	gin run start 
 
 install-templ:
 	go install github.com/a-h/templ/cmd/templ@$(shell go list -m -f '{{ .Version }}' github.com/a-h/templ)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 start:
 	gin run start
 
-build-static:
-	./scripts/build-static.sh
-
 templ:
 	templ generate --watch --path=web/templ
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 start:
 	gin run start
 
+install-templ:
+	go install github.com/a-h/templ/cmd/templ@$(shell go list -m -f '{{ .Version }}' github.com/a-h/templ)
+
 templ:
 	templ generate --watch --path=web/templ
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       dockerfile: .docker/Dockerfile.tailwindcss
     tty: true
     volumes:
-      - ./web:/app/web
+      - ./:/app
 
   gin-watcher:
     image: alehechka/dqix/gin-watcher

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,29 @@
 version: '3.8'
 
 services:
-  dqix:
-    image: alehechka/dqix
+  templ-watcher:
+    image: alehechka/dqix/templ-watcher
     build:
       context: .
-      dockerfile: Dockerfile
-    command: start
+      dockerfile: .docker/Dockerfile.templ
+    volumes:
+      - ./web/templ:/app/web/templ
+
+  tailwindcss-watcher:
+    image: alehechka/dqix/tailwindcss-watcher
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile.tailwindcss
+    tty: true
+    volumes:
+      - ./web:/app/web
+
+  gin-watcher:
+    image: alehechka/dqix/gin-watcher
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile.gin
+    volumes:
+      - ./:/app
     ports:
-      - 8080:8080
+      - 3000:3000

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module dqix
 go 1.21
 
 require (
-	github.com/a-h/templ v0.2.501
+	github.com/a-h/templ v0.2.513
 	github.com/gin-contrib/gzip v0.0.6
 	github.com/gin-gonic/gin v1.9.1
 	github.com/urfave/cli/v2 v2.26.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/a-h/templ v0.2.501 h1:9rIo5u+B+NDJIkbHGthckUGRguCuWKY/7ri8e2ckn9M=
 github.com/a-h/templ v0.2.501/go.mod h1:9gZxTLtRzM3gQxO8jr09Na0v8/jfliS97S9W5SScanM=
+github.com/a-h/templ v0.2.513 h1:ZmwGAOx4NYllnHy+FTpusc4+c5msoMpPIYX0Oy3dNqw=
+github.com/a-h/templ v0.2.513/go.mod h1:9gZxTLtRzM3gQxO8jr09Na0v8/jfliS97S9W5SScanM=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=


### PR DESCRIPTION
# Overview
A few DX enhancements. Mainly added a docker-compose setup that can run the entire development setup from containers instead of on the host machine. 

For some reason, the above doesn't work on my Ubuntu machine. Mainly the gin image throws the following error and never starts:
```
[gin] Build failed
go: downloading github.com/a-h/templ v0.2.513
error obtaining VCS status: exit status 128
Use -buildvcs=false to disable VCS stamping.
```