### PR TITLE
Conditionally render theme toggle icon based on theme

### DIFF
--- a/web/templ/components/buttons/theme-button.templ
+++ b/web/templ/components/buttons/theme-button.templ
@@ -11,10 +11,7 @@ script clientThemeToggle() {
 
 templ ThemeToggleButton(isDarkMode bool) {
 	<button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded p-1" onclick={ clientThemeToggle() }>
-		if isDarkMode {
-			@icons.Moon()
-		} else {
-			@icons.Sun()
-		}
+		@icons.Moon(icons.WithClass("hidden dark:block"))
+		@icons.Sun(icons.WithClass("block dark:hidden"))
 	</button>
 }


### PR DESCRIPTION
# Overview
In the original implementation of the theme toggle button, it would make a request via HTMX and replace the button wholesale with a new button that included the proper icon. Because this implementation was replaced with a client-side-only implementation via JS, the icon is not properly changed with the theme.

This implementation creates the button with both icons inside and opposite display CSS for dark/light themes on each.