### PR TITLE
Param Drilling and CSS Versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY tailwind.config.js .
 COPY web/templ web/templ
 COPY web/static web/static
 
-RUN npm run build:css
+ARG RELEASE_VERSION=latest
+RUN VERSION=${RELEASE_VERSION} npm run build:css
 
 # GENERATE TEMPL
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -8,7 +8,10 @@ import (
 )
 
 func start(ctx *cli.Context) (err error) {
-	return router.NewRouter(router.WithData(ctx.String(flags.ArgDataPath))).Run(ctx.Int(flags.ArgPort))
+	return router.NewRouter(
+		router.WithData(ctx.String(flags.ArgDataPath)),
+		router.WithCSSVersion(ctx.App.Version),
+	).Run(ctx.Int(flags.ArgPort))
 }
 
 // StartCommand starts the application.

--- a/internal/router/app.go
+++ b/internal/router/app.go
@@ -9,8 +9,9 @@ import (
 )
 
 type app struct {
-	dataPath string
-	data     data
+	dataPath   string
+	data       data
+	cssVersion string
 }
 
 type data struct {
@@ -118,4 +119,16 @@ func (a *app) loadInventory(basePath string) error {
 
 		return nil
 	})
+}
+
+type cssVersionOption struct {
+	cssVersion string
+}
+
+func WithCSSVersion(cssVersion string) RouterOption {
+	return &cssVersionOption{cssVersion: cssVersion}
+}
+
+func (o cssVersionOption) apply(a *app) {
+	a.cssVersion = o.cssVersion
 }

--- a/internal/router/inventory.go
+++ b/internal/router/inventory.go
@@ -3,8 +3,10 @@ package router
 import (
 	gin_utils "dqix/pkg/gin"
 	"dqix/pkg/htmx"
+	"dqix/web/templ/components/base"
 	"dqix/web/templ/pages"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -32,7 +34,12 @@ func (a *app) InventoryRoutes(engine *gin.Engine) {
 			Inventories:    inventories,
 			Stats:          inventories.GetHasInventoryStats(),
 			DisplayMode:    ctx.Query("display"),
-			IsDarkMode:     gin_utils.IsDarkMode(ctx),
+			LayoutParams: base.LayoutParams{
+				PageTitle:  "DQIX | " + strings.Title(classification),
+				Page:       classification,
+				IsDarkMode: gin_utils.IsDarkMode(ctx),
+				CSSVersion: a.cssVersion,
+			},
 		}
 
 		switch htmx.GetHxSwapTarget(ctx) {
@@ -58,18 +65,29 @@ func (a *app) InventoryRoutes(engine *gin.Engine) {
 			return
 		}
 
+		params := pages.InventoryParams{
+			Inventory: inventory,
+			Getter:    a.data.GetQuickThing,
+			LayoutParams: base.LayoutParams{
+				PageTitle:  "DQIX | " + inventory.Title,
+				Page:       inventory.Classification,
+				IsDarkMode: gin_utils.IsDarkMode(ctx),
+				CSSVersion: a.cssVersion,
+			},
+		}
+
 		switch htmx.GetHxSwapTarget(ctx) {
 		case "page-content":
 			if htmx.HasMatchingParentPath(ctx) {
-				ctx.HTML(http.StatusOK, "", pages.InventoryContent(inventory, a.data.GetQuickThing))
+				ctx.HTML(http.StatusOK, "", pages.InventoryContent(params))
 			} else {
 				htmx.Retarget(ctx, "#sidenav-page-wrapper")
-				ctx.HTML(http.StatusOK, "", pages.InventoryContentWithSideNav(inventory, a.data.GetQuickThing))
+				ctx.HTML(http.StatusOK, "", pages.InventoryContentWithSideNav(params))
 			}
 		case "sidenav-page-wrapper":
-			ctx.HTML(http.StatusOK, "", pages.InventoryContentWithSideNav(inventory, a.data.GetQuickThing))
+			ctx.HTML(http.StatusOK, "", pages.InventoryContentWithSideNav(params))
 		default:
-			ctx.HTML(http.StatusOK, "", pages.InventoryPage(inventory, a.data.GetQuickThing, gin_utils.IsDarkMode(ctx)))
+			ctx.HTML(http.StatusOK, "", pages.InventoryPage(params))
 		}
 	})
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	gin_utils "dqix/pkg/gin"
+	"dqix/web/templ/components/base"
 	"dqix/web/templ/pages"
 	"fmt"
 	"net/http"
@@ -38,7 +39,14 @@ func (a *app) SetupRouter() *gin.Engine {
 	a.StaticFiles(engine)
 
 	engine.GET("/", func(ctx *gin.Context) {
-		ctx.HTML(http.StatusOK, "", pages.IndexPage(gin_utils.IsDarkMode(ctx)))
+		params := pages.IndexParams{
+			LayoutParams: base.LayoutParams{
+				PageTitle:  "Dragon Quest IX",
+				IsDarkMode: gin_utils.IsDarkMode(ctx),
+				CSSVersion: a.cssVersion,
+			},
+		}
+		ctx.HTML(http.StatusOK, "", pages.IndexPage(params))
 	})
 
 	a.InventoryRoutes(engine)

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build:css:dev": "tailwindcss -i web/static/input.css -o web/static/output.dev.css",
-    "build:css": "NODE_ENV=production tailwindcss -i web/static/input.css -o web/static/output.css --minify",
-    "watch:css": "NODE_ENV=production tailwindcss -i web/static/input.css -o web/static/output.css --minify --watch",
+    "build:css": "NODE_ENV=production tailwindcss -i web/static/input.css -o web/static/output.$VERSION.css --minify",
+    "watch:css": "NODE_ENV=production tailwindcss -i web/static/input.css -o web/static/output.dev.css --minify --watch",
     "pretty": "prettier . --write"
   },
   "repository": {

--- a/web/templ/components/base/layout.templ
+++ b/web/templ/components/base/layout.templ
@@ -3,21 +3,28 @@ package base
 import "dqix/web/templ/components/icons"
 import "dqix/web/templ/components/buttons"
 
-templ Layout(pageTitle string, page string, isDarkMode bool) {
+type LayoutParams struct {
+	PageTitle  string
+	Page       string
+	IsDarkMode bool
+	CSSVersion string
+}
+
+templ Layout(params LayoutParams) {
 	<html
 		lang="en"
 		class="h-full overflow-hidden"
-		if isDarkMode {
+		if params.IsDarkMode {
 			data-mode="dark"
 		}
 	>
 		<head>
-			@Meta(pageTitle)
+			@Meta(params.PageTitle, params.CSSVersion)
 		</head>
 		<body class="h-full overflow-hidden dark:text-gray-300">
 			@sidenavScriptUtils()
-			@Navbar(isDarkMode)
-			@MainContentWithSidenav(page) {
+			@Navbar(params.IsDarkMode)
+			@MainContentWithSidenav(params.Page) {
 				{ children... }
 			}
 		</body>

--- a/web/templ/components/base/layout.templ
+++ b/web/templ/components/base/layout.templ
@@ -1,6 +1,5 @@
 package base
 
-import "dqix/web/templ/components/icons"
 import "dqix/web/templ/components/buttons"
 
 type LayoutParams struct {
@@ -22,7 +21,6 @@ templ Layout(params LayoutParams) {
 			@Meta(params.PageTitle, params.CSSVersion)
 		</head>
 		<body class="h-full overflow-hidden dark:text-gray-300">
-			@sidenavScriptUtils()
 			@Navbar(params.IsDarkMode)
 			@MainContentWithSidenav(params.Page) {
 				{ children... }
@@ -75,9 +73,7 @@ templ Navbar(isDarkMode bool) {
 		</a>
 		<div class="flex flex-row gap-2 mr-4 items-center">
 			@buttons.ThemeToggleButton(isDarkMode)
-			<button class="block md:hidden hover:bg-gray-200 dark:hover:bg-gray-600 rounded p-1" onclick={ toggleSidenav() }>
-				@icons.Hamburger(icons.WithSize("1.25rem"))
-			</button>
+			@buttons.SidenavToggleButton()
 		</div>
 	</header>
 }

--- a/web/templ/components/base/meta.templ
+++ b/web/templ/components/base/meta.templ
@@ -1,19 +1,21 @@
 package base
 
-templ Meta(pageTitle string) {
+import "fmt"
+
+templ Meta(pageTitle string, cssVersion string) {
 	<meta charset="UTF-8"/>
 	<meta
- 		name="viewport"
- 		content="width=device-width, initial-scale=1, maximum-scale=5"
+		name="viewport"
+		content="width=device-width, initial-scale=1, maximum-scale=5"
 	/>
 	<meta
- 		name="description"
- 		content="Imp is focused on building the premier small, business Inventory Management Product."
+		name="description"
+		content="Imp is focused on building the premier small, business Inventory Management Product."
 	/>
 	<script defer src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
 	<script defer src="https://unpkg.com/htmx.org@1.9.10/dist/ext/loading-states.js" integrity="sha384-v04dReCP6N+wBCc+JjDUHyvkWJPO5jyzXxNdZHF/HZVyMXhh2USfi3UvCfiPwmmB" crossorigin="anonymous"></script>
 	<link rel="icon" type="image/x-icon" href="/static/favicon.ico"/>
-	<link rel="stylesheet" href="/static/output.css"/>
+	<link rel="stylesheet" href={ fmt.Sprintf("/static/output.%s.css", cssVersion) }/>
 	<title>
 		{ pageTitle }
 	</title>

--- a/web/templ/components/base/meta.templ
+++ b/web/templ/components/base/meta.templ
@@ -14,6 +14,7 @@ templ Meta(pageTitle string, cssVersion string) {
 	/>
 	<script defer src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
 	<script defer src="https://unpkg.com/htmx.org@1.9.10/dist/ext/loading-states.js" integrity="sha384-v04dReCP6N+wBCc+JjDUHyvkWJPO5jyzXxNdZHF/HZVyMXhh2USfi3UvCfiPwmmB" crossorigin="anonymous"></script>
+	@sidenavScriptUtils()
 	<link rel="icon" type="image/x-icon" href="/static/favicon.ico"/>
 	<link rel="stylesheet" href={ fmt.Sprintf("/static/output.%s.css", cssVersion) }/>
 	<title>

--- a/web/templ/components/base/sidenav.templ
+++ b/web/templ/components/base/sidenav.templ
@@ -25,8 +25,8 @@ templ SideNav(page string) {
 				>
 					<summary>Items</summary>
 					<ul class="flex flex-col gap-1 overflow-x-hidden">
-						@SideNavLink("Everyday", fn.Path("inventory", "bag", "items", types.ClassItemEveryday), page == types.ClassItemEveryday)
-						@SideNavLink("Important", fn.Path("inventory", "bag", "items", types.ClassItemImportant), page == types.ClassItemImportant)
+						@sideNavLink("Everyday", fn.Path("inventory", "bag", "items", types.ClassItemEveryday), page == types.ClassItemEveryday)
+						@sideNavLink("Important", fn.Path("inventory", "bag", "items", types.ClassItemImportant), page == types.ClassItemImportant)
 					</ul>
 				</details>
 			</li>
@@ -39,12 +39,12 @@ templ SideNav(page string) {
 				>
 					<summary>Armor</summary>
 					<ul class="flex flex-col gap-1 overflow-x-hidden">
-						@SideNavLink("Head", fn.Path("inventory", "equipment", "armor", types.ClassArmorHead), page == types.ClassArmorHead)
-						@SideNavLink("Torso", fn.Path("inventory", "equipment", "armor", types.ClassArmorTorso), page == types.ClassArmorTorso)
-						@SideNavLink("Shields", fn.Path("inventory", "equipment", "armor", types.ClassArmorShield), page == types.ClassArmorShield)
-						@SideNavLink("Arms", fn.Path("inventory", "equipment", "armor", types.ClassArmorArms), page == types.ClassArmorArms)
-						@SideNavLink("Legs", fn.Path("inventory", "equipment", "armor", types.ClassArmorLegs), page == types.ClassArmorLegs)
-						@SideNavLink("Feet", fn.Path("inventory", "equipment", "armor", types.ClassArmorFeet), page == types.ClassArmorFeet)
+						@sideNavLink("Head", fn.Path("inventory", "equipment", "armor", types.ClassArmorHead), page == types.ClassArmorHead)
+						@sideNavLink("Torso", fn.Path("inventory", "equipment", "armor", types.ClassArmorTorso), page == types.ClassArmorTorso)
+						@sideNavLink("Shields", fn.Path("inventory", "equipment", "armor", types.ClassArmorShield), page == types.ClassArmorShield)
+						@sideNavLink("Arms", fn.Path("inventory", "equipment", "armor", types.ClassArmorArms), page == types.ClassArmorArms)
+						@sideNavLink("Legs", fn.Path("inventory", "equipment", "armor", types.ClassArmorLegs), page == types.ClassArmorLegs)
+						@sideNavLink("Feet", fn.Path("inventory", "equipment", "armor", types.ClassArmorFeet), page == types.ClassArmorFeet)
 					</ul>
 				</details>
 			</li>
@@ -57,29 +57,29 @@ templ SideNav(page string) {
 				>
 					<summary>Weapons</summary>
 					<ul class="flex flex-col gap-1 overflow-x-hidden">
-						@SideNavLink("Axes", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponAxe), page == types.ClassWeaponAxe)
-						@SideNavLink("Boomerangs", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponBoomerang), page == types.ClassWeaponBoomerang)
-						@SideNavLink("Bows", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponBow), page == types.ClassWeaponBow)
-						@SideNavLink("Claws", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponClaw), page == types.ClassWeaponClaw)
-						@SideNavLink("Fans", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponFan), page == types.ClassWeaponFan)
-						@SideNavLink("Hammers", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponHammer), page == types.ClassWeaponHammer)
-						@SideNavLink("Knives", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponKnife), page == types.ClassWeaponKnife)
-						@SideNavLink("Spears", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponSpear), page == types.ClassWeaponSpear)
-						@SideNavLink("Staves", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponStave), page == types.ClassWeaponStave)
-						@SideNavLink("Swords", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponSword), page == types.ClassWeaponSword)
-						@SideNavLink("Wands", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponWand), page == types.ClassWeaponWand)
-						@SideNavLink("Whips", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponWhip), page == types.ClassWeaponWhip)
+						@sideNavLink("Axes", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponAxe), page == types.ClassWeaponAxe)
+						@sideNavLink("Boomerangs", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponBoomerang), page == types.ClassWeaponBoomerang)
+						@sideNavLink("Bows", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponBow), page == types.ClassWeaponBow)
+						@sideNavLink("Claws", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponClaw), page == types.ClassWeaponClaw)
+						@sideNavLink("Fans", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponFan), page == types.ClassWeaponFan)
+						@sideNavLink("Hammers", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponHammer), page == types.ClassWeaponHammer)
+						@sideNavLink("Knives", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponKnife), page == types.ClassWeaponKnife)
+						@sideNavLink("Spears", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponSpear), page == types.ClassWeaponSpear)
+						@sideNavLink("Staves", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponStave), page == types.ClassWeaponStave)
+						@sideNavLink("Swords", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponSword), page == types.ClassWeaponSword)
+						@sideNavLink("Wands", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponWand), page == types.ClassWeaponWand)
+						@sideNavLink("Whips", fn.Path("inventory", "equipment", "weapon", types.ClassWeaponWhip), page == types.ClassWeaponWhip)
 					</ul>
 				</details>
 			</li>
 			<li>
-				@SideNavLink("Accessories", fn.Path("inventory", "equipment", "accessories", types.ClassAccessory), page == types.ClassAccessory)
+				@sideNavLink("Accessories", fn.Path("inventory", "equipment", "accessories", types.ClassAccessory), page == types.ClassAccessory)
 			</li>
 		</ul>
 	</aside>
 }
 
-templ SideNavLink(text string, href templ.SafeURL, isActive bool) {
+templ sideNavLink(text string, href templ.SafeURL, isActive bool) {
 	<li>
 		<a
 			href={ href }
@@ -114,9 +114,4 @@ script sidenavScriptUtils() {
 	}
 
 	sm.addEventListener('change', closeSidenav);
-}
-
-script toggleSidenav() {
-	var x = document.getElementById('sidenav').getAttribute('aria-expanded') === 'true' ? 'false' : 'true';
-  	document.getElementById('sidenav').setAttribute('aria-expanded', x);
 }

--- a/web/templ/components/buttons/sidenav-button.templ
+++ b/web/templ/components/buttons/sidenav-button.templ
@@ -1,0 +1,16 @@
+package buttons
+
+import "dqix/web/templ/components/icons"
+
+script toggleSidenav() {
+	var x = document.getElementById('sidenav').getAttribute('aria-expanded') === 'true' ? 'false' : 'true';
+  	document.getElementById('sidenav').setAttribute('aria-expanded', x);
+}
+
+templ SidenavToggleButton() {
+	<div id="sidenav-toggle-wrapper">
+		<button class="block md:hidden hover:bg-gray-200 dark:hover:bg-gray-600 rounded p-1" onclick={ toggleSidenav() }>
+			@icons.Hamburger(icons.WithSize("1.25rem"))
+		</button>
+	</div>
+}

--- a/web/templ/components/buttons/theme-button.templ
+++ b/web/templ/components/buttons/theme-button.templ
@@ -10,8 +10,10 @@ script clientThemeToggle() {
 }
 
 templ ThemeToggleButton(isDarkMode bool) {
-	<button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded p-1" onclick={ clientThemeToggle() }>
-		@icons.Moon(icons.WithClass("hidden dark:block"))
-		@icons.Sun(icons.WithClass("block dark:hidden"))
-	</button>
+	<div id="theme-toggle-wrapper">
+		<button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded p-1" onclick={ clientThemeToggle() }>
+			@icons.Moon(icons.WithClass("hidden dark:block"))
+			@icons.Sun(icons.WithClass("block dark:hidden"))
+		</button>
+	</div>
 }

--- a/web/templ/pages/index.templ
+++ b/web/templ/pages/index.templ
@@ -2,8 +2,12 @@ package pages
 
 import "dqix/web/templ/components/base"
 
-templ IndexPage(isDarkMode bool) {
-	@base.Layout("Dragon Quest IX", "", isDarkMode) {
+type IndexParams struct {
+	LayoutParams base.LayoutParams
+}
+
+templ IndexPage(params IndexParams) {
+	@base.Layout(params.LayoutParams) {
 		@indexContent()
 	}
 }

--- a/web/templ/pages/inventory-classifications.templ
+++ b/web/templ/pages/inventory-classifications.templ
@@ -81,7 +81,7 @@ templ InventoryClassificationTable(params InventoryClassificationParams) {
 				}
 			</tr>
 		</thead>
-		<tbody role="rowgroup" class="[&>tr:nth-child(odd)]:bg-gray-200" hx-boost="true" hx-target="#page-content" hx-swap="innerHTML">
+		<tbody role="rowgroup" class="[&>tr:nth-child(odd)]:bg-gray-200 dark:[&>tr:nth-child(odd)]:bg-zinc-800" hx-boost="true" hx-target="#page-content" hx-swap="innerHTML">
 			for _, inventory := range params.Inventories {
 				<tr key={ inventory.ID } role="row" class="[&>td]:py-2 [&>td]:pr-4">
 					<td role="cell" data-cell="image" width="49px">

--- a/web/templ/pages/inventory-classifications.templ
+++ b/web/templ/pages/inventory-classifications.templ
@@ -14,11 +14,11 @@ type InventoryClassificationParams struct {
 	Inventories    types.InventorySlice
 	Stats          types.HasInventoryStats
 	DisplayMode    string
-	IsDarkMode     bool
+	LayoutParams   base.LayoutParams
 }
 
 templ InventoryClassificationPage(params InventoryClassificationParams) {
-	@base.Layout("DQIX | " + strings.Title(params.Classification), params.Classification, params.IsDarkMode) {
+	@base.Layout(params.LayoutParams) {
 		@InventoryClassificationContent(params)
 	}
 }

--- a/web/templ/pages/inventory.templ
+++ b/web/templ/pages/inventory.templ
@@ -8,110 +8,117 @@ import "strconv"
 import "fmt"
 
 // Inventory
-templ InventoryPage(inventory types.Inventory, getter types.IGetThingFromID, isDarkMode bool) {
-	@base.Layout("DQIX | " + inventory.Title, inventory.Classification, isDarkMode) {
-		@InventoryContent(inventory, getter)
+
+type InventoryParams struct {
+	Inventory    types.Inventory
+	Getter       types.IGetThingFromID
+	LayoutParams base.LayoutParams
+}
+
+templ InventoryPage(params InventoryParams) {
+	@base.Layout(params.LayoutParams) {
+		@InventoryContent(params)
 	}
 }
 
-templ InventoryContentWithSideNav(inventory types.Inventory, getter types.IGetThingFromID) {
-	@base.MainContentWithSidenav(inventory.Classification) {
-		@InventoryContent(inventory, getter)
+templ InventoryContentWithSideNav(params InventoryParams) {
+	@base.MainContentWithSidenav(params.Inventory.Classification) {
+		@InventoryContent(params)
 	}
 }
 
-templ InventoryContent(inventory types.Inventory, getter types.IGetThingFromID) {
+templ InventoryContent(params InventoryParams) {
 	<div hx-boost="true" hx-target="#page-content">
 		<div class="flex flex-row items-center">
-			<img src={ inventory.ImageSrc() } alt={ inventory.ID }/>
+			<img src={ params.Inventory.ImageSrc() } alt={ params.Inventory.ID }/>
 			<h1 id="title" class="text-3xl font-bold">
-				{ inventory.Title }
+				{ params.Inventory.Title }
 			</h1>
 		</div>
 		<hr/>
-		<p id="description" class="pt-4 pb-2">{ inventory.Description }</p>
-		if inventory.Statistics != (types.Statistics{}) {
+		<p id="description" class="pt-4 pb-2">{ params.Inventory.Description }</p>
+		if params.Inventory.Statistics != (types.Statistics{}) {
 			<p id="statistics" class="py-2">
-				if inventory.Statistics.Attack > 0 {
-					<strong>Attack: </strong>{ strconv.Itoa(inventory.Statistics.Attack) }
+				if params.Inventory.Statistics.Attack > 0 {
+					<strong>Attack: </strong>{ strconv.Itoa(params.Inventory.Statistics.Attack) }
 					<br/>
 				}
-				if inventory.Statistics.Defense > 0 {
-					<strong>Defense: </strong>{ strconv.Itoa(inventory.Statistics.Defense) }
+				if params.Inventory.Statistics.Defense > 0 {
+					<strong>Defense: </strong>{ strconv.Itoa(params.Inventory.Statistics.Defense) }
 					<br/>
 				}
-				if inventory.Statistics.BlockChance > 0 {
-					<strong>Block Chance: </strong>{ fmt.Sprintf("%.2f%%", inventory.Statistics.BlockChance) }
+				if params.Inventory.Statistics.BlockChance > 0 {
+					<strong>Block Chance: </strong>{ fmt.Sprintf("%.2f%%", params.Inventory.Statistics.BlockChance) }
 					<br/>
 				}
-				if inventory.Statistics.Agility > 0 {
-					<strong>Agility: </strong>{ strconv.Itoa(inventory.Statistics.Agility) }
+				if params.Inventory.Statistics.Agility > 0 {
+					<strong>Agility: </strong>{ strconv.Itoa(params.Inventory.Statistics.Agility) }
 					<br/>
 				}
-				if inventory.Statistics.EvasionChance > 0 {
-					<strong>Evasion Chance: </strong>{ fmt.Sprintf("%.2f%%", inventory.Statistics.EvasionChance) }
+				if params.Inventory.Statistics.EvasionChance > 0 {
+					<strong>Evasion Chance: </strong>{ fmt.Sprintf("%.2f%%", params.Inventory.Statistics.EvasionChance) }
 					<br/>
 				}
-				if inventory.Statistics.MagicalMight > 0 {
-					<strong>Magical Might: </strong>{ strconv.Itoa(inventory.Statistics.MagicalMight) }
+				if params.Inventory.Statistics.MagicalMight > 0 {
+					<strong>Magical Might: </strong>{ strconv.Itoa(params.Inventory.Statistics.MagicalMight) }
 					<br/>
 				}
-				if inventory.Statistics.MagicalMending > 0 {
-					<strong>Magical Mending: </strong>{ strconv.Itoa(inventory.Statistics.MagicalMending) }
+				if params.Inventory.Statistics.MagicalMending > 0 {
+					<strong>Magical Mending: </strong>{ strconv.Itoa(params.Inventory.Statistics.MagicalMending) }
 					<br/>
 				}
-				if inventory.Statistics.MPAbsorptionRate > 0 {
-					<strong>MP Absorption Rate: </strong>{ fmt.Sprintf("%.2f%%", inventory.Statistics.MPAbsorptionRate) }
+				if params.Inventory.Statistics.MPAbsorptionRate > 0 {
+					<strong>MP Absorption Rate: </strong>{ fmt.Sprintf("%.2f%%", params.Inventory.Statistics.MPAbsorptionRate) }
 					<br/>
 				}
-				if inventory.Statistics.Deftness > 0 {
-					<strong>Deftness: </strong>{ strconv.Itoa(inventory.Statistics.Deftness) }
+				if params.Inventory.Statistics.Deftness > 0 {
+					<strong>Deftness: </strong>{ strconv.Itoa(params.Inventory.Statistics.Deftness) }
 					<br/>
 				}
-				if inventory.Statistics.Charm > 0 {
-					<strong>Charm: </strong>{ strconv.Itoa(inventory.Statistics.Charm) }
+				if params.Inventory.Statistics.Charm > 0 {
+					<strong>Charm: </strong>{ strconv.Itoa(params.Inventory.Statistics.Charm) }
 					<br/>
 				}
-				if inventory.Statistics.Special != (types.Special{}) {
+				if params.Inventory.Statistics.Special != (types.Special{}) {
 					<strong>Special: </strong>
 					<br/>
-					if inventory.Statistics.Special.Effect != "" {
-						<em class="pl-2">Effect: </em> { inventory.Statistics.Special.Effect }
+					if params.Inventory.Statistics.Special.Effect != "" {
+						<em class="pl-2">Effect: </em> { params.Inventory.Statistics.Special.Effect }
 						<br/>
 					}
-					if inventory.Statistics.Special.Usage != "" {
-						<em class="pl-2">Usage: </em> { inventory.Statistics.Special.Usage }
+					if params.Inventory.Statistics.Special.Usage != "" {
+						<em class="pl-2">Usage: </em> { params.Inventory.Statistics.Special.Usage }
 						<br/>
 					}
-					if inventory.Statistics.Special.Curse != "" {
-						<em class="pl-2">Curse: </em> { inventory.Statistics.Special.Curse }
+					if params.Inventory.Statistics.Special.Curse != "" {
+						<em class="pl-2">Curse: </em> { params.Inventory.Statistics.Special.Curse }
 						<br/>
 					}
 				}
 			</p>
 		}
 		<p id="details" class="py-2">
-			<strong>Rarity: </strong>{ fmt.Sprintf("%d/5", inventory.Rarity) }
+			<strong>Rarity: </strong>{ fmt.Sprintf("%d/5", params.Inventory.Rarity) }
 			<br/>
-			if inventory.BuyPrice > 0 {
-				<strong>Buy price: </strong>{ fmt.Sprintf("%d gold", inventory.BuyPrice) }
+			if params.Inventory.BuyPrice > 0 {
+				<strong>Buy price: </strong>{ fmt.Sprintf("%d gold", params.Inventory.BuyPrice) }
 				<br/>
 			}
-			if inventory.SellPrice > 0 {
-				<strong>Sell price: </strong>{ fmt.Sprintf("%d gold", inventory.SellPrice) }
+			if params.Inventory.SellPrice > 0 {
+				<strong>Sell price: </strong>{ fmt.Sprintf("%d gold", params.Inventory.SellPrice) }
 				<br/>
 			}
-			if len(inventory.Vocations) > 0 {
-				<strong>Used by: </strong>{ strings.Join(inventory.Vocations, ", ") }
+			if len(params.Inventory.Vocations) > 0 {
+				<strong>Used by: </strong>{ strings.Join(params.Inventory.Vocations, ", ") }
 				<br/>
 			}
-			<strong>Classification: </strong>{ inventory.Classification }
+			<strong>Classification: </strong>{ params.Inventory.Classification }
 		</p>
-		if len(inventory.LocationsFound) > 0 {
+		if len(params.Inventory.LocationsFound) > 0 {
 			<div id="locations-found" class="py-2">
 				<strong>Where to find:</strong>
 				<ul class="pl-8 list-disc">
-					for _, location := range inventory.LocationsFound {
+					for _, location := range params.Inventory.LocationsFound {
 						<li>
 							{ location }
 						</li>
@@ -119,13 +126,13 @@ templ InventoryContent(inventory types.Inventory, getter types.IGetThingFromID) 
 				</ul>
 			</div>
 		}
-		if len(inventory.DroppedBy) > 0 {
+		if len(params.Inventory.DroppedBy) > 0 {
 			<div id="dropped-by" class="py-2">
 				<strong>Dropped by:</strong>
 				<ul class="pl-8 list-disc">
-					for monster, dropRate := range inventory.DroppedBy {
+					for monster, dropRate := range params.Inventory.DroppedBy {
 						<li>
-							@links.ThingLink(monster, getter)
+							@links.ThingLink(monster, params.Getter)
 							<span>
 								&nbsp;{ dropRate }
 							</span>
@@ -134,49 +141,49 @@ templ InventoryContent(inventory types.Inventory, getter types.IGetThingFromID) 
 				</ul>
 			</div>
 		}
-		if len(inventory.Recipe) > 0 {
+		if len(params.Inventory.Recipe) > 0 {
 			<div id="recipe" class="py-2">
 				<strong>Recipe: </strong>
-				for index, ingredient := range inventory.RecipeSlice() {
+				for index, ingredient := range params.Inventory.RecipeSlice() {
 					if index > 0 {
 						<span>&nbsp;+ </span>
 					}
-					@links.ThingLink(ingredient.ID, getter)
+					@links.ThingLink(ingredient.ID, params.Getter)
 					<span>&times;{ strconv.Itoa(ingredient.Quantity) }</span>
 				}
 			</div>
 		}
-		if len(inventory.IngredientFor) > 0 {
+		if len(params.Inventory.IngredientFor) > 0 {
 			<div id="alchemises" class="py-2">
 				<strong>Alchemises:</strong>
 				<ul class="pl-8 list-disc">
-					for _, id := range inventory.IngredientFor {
+					for _, id := range params.Inventory.IngredientFor {
 						<li>
-							@links.ThingLink(id, getter)
+							@links.ThingLink(id, params.Getter)
 						</li>
 					}
 				</ul>
 			</div>
 		}
-		if len(inventory.RequiredFor) > 0 {
+		if len(params.Inventory.RequiredFor) > 0 {
 			<div id="required-for" class="py-2">
 				<strong>Required for:</strong>
 				<ul class="pl-8 list-disc">
-					for _, id := range inventory.RequiredFor {
+					for _, id := range params.Inventory.RequiredFor {
 						<li>
-							@links.ThingLink(id, getter)
+							@links.ThingLink(id, params.Getter)
 						</li>
 					}
 				</ul>
 			</div>
 		}
-		if len(inventory.CanBeUsedFor) > 0 {
+		if len(params.Inventory.CanBeUsedFor) > 0 {
 			<div id="can-be-used-for" class="py-2">
 				<strong>Can be used for:</strong>
 				<ul class="pl-8 list-disc">
-					for _, id := range inventory.CanBeUsedFor {
+					for _, id := range params.Inventory.CanBeUsedFor {
 						<li>
-							@links.ThingLink(id, getter)
+							@links.ThingLink(id, params.Getter)
 						</li>
 					}
 				</ul>


### PR DESCRIPTION
# Overview
This PR adds "Param Drilling" (aka prop drilling from React) to all available pages. Additionally, it adds CSS versioning so that a new build will always pull in the correct CSS instead of a cached version potentially getting rendered.

Finally, I better encapsulated some of the templ scripts so that the JS and HTML will have a parent div with appropriate id attribute.