### PR TITLE
Icon Header htmx Extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "cSpell.words": ["armamentalist", "Wikidot"],
+  "cSpell.words": ["armamentalist", "htmx", "Wikidot"],
   "css.customData": [".vscode/tailwind.json"],
   "editor.formatOnSave": true,
   "[json]": {

--- a/internal/router/inventory.go
+++ b/internal/router/inventory.go
@@ -31,7 +31,7 @@ func (a *app) InventoryRoutes(engine *gin.Engine) {
 		}
 
 		pageTitle := "DQIX | " + strings.Title(classification)
-		ctx.Header(htmx.ResponseHeaderTitle, pageTitle)
+		htmx.SetTitle(ctx, pageTitle)
 		params := pages.InventoryClassificationParams{
 			Classification:  classification,
 			Inventories:     inventories,
@@ -73,7 +73,7 @@ func (a *app) InventoryRoutes(engine *gin.Engine) {
 		}
 
 		pageTitle := "DQIX | " + inventory.Title
-		ctx.Header(htmx.ResponseHeaderTitle, pageTitle)
+		htmx.SetTitle(ctx, pageTitle)
 		params := pages.InventoryParams{
 			Inventory: inventory,
 			Getter:    a.data.GetQuickThing,

--- a/internal/router/inventory.go
+++ b/internal/router/inventory.go
@@ -30,6 +30,8 @@ func (a *app) InventoryRoutes(engine *gin.Engine) {
 			return
 		}
 
+		pageTitle := "DQIX | " + strings.Title(classification)
+		ctx.Header(htmx.ResponseHeaderTitle, pageTitle)
 		params := pages.InventoryClassificationParams{
 			Classification:  classification,
 			Inventories:     inventories,
@@ -38,7 +40,7 @@ func (a *app) InventoryRoutes(engine *gin.Engine) {
 			SortPathGetter:  types.PrepareSimpleSortPath(*ctx.Request.URL),
 			SortOrderGetter: types.GetSortOrder(ctx.Request.URL),
 			LayoutParams: base.LayoutParams{
-				PageTitle:  "DQIX | " + strings.Title(classification),
+				PageTitle:  pageTitle,
 				Page:       classification,
 				IsDarkMode: gin_utils.IsDarkMode(ctx),
 				CSSVersion: a.cssVersion,
@@ -70,11 +72,13 @@ func (a *app) InventoryRoutes(engine *gin.Engine) {
 			return
 		}
 
+		pageTitle := "DQIX | " + inventory.Title
+		ctx.Header(htmx.ResponseHeaderTitle, pageTitle)
 		params := pages.InventoryParams{
 			Inventory: inventory,
 			Getter:    a.data.GetQuickThing,
 			LayoutParams: base.LayoutParams{
-				PageTitle:  "DQIX | " + inventory.Title,
+				PageTitle:  pageTitle,
 				Page:       inventory.Classification,
 				IsDarkMode: gin_utils.IsDarkMode(ctx),
 				CSSVersion: a.cssVersion,

--- a/internal/router/inventory.go
+++ b/internal/router/inventory.go
@@ -32,6 +32,7 @@ func (a *app) InventoryRoutes(engine *gin.Engine) {
 
 		pageTitle := "DQIX | " + strings.Title(classification)
 		htmx.SetTitle(ctx, pageTitle)
+		htmx.SetIcon(ctx, "/static/favicon.ico")
 		params := pages.InventoryClassificationParams{
 			Classification:  classification,
 			Inventories:     inventories,

--- a/internal/router/inventory.go
+++ b/internal/router/inventory.go
@@ -74,6 +74,7 @@ func (a *app) InventoryRoutes(engine *gin.Engine) {
 
 		pageTitle := "DQIX | " + inventory.Title
 		htmx.SetTitle(ctx, pageTitle)
+		htmx.SetIcon(ctx, inventory.ImageSrc())
 		params := pages.InventoryParams{
 			Inventory: inventory,
 			Getter:    a.data.GetQuickThing,

--- a/pkg/htmx/gin.go
+++ b/pkg/htmx/gin.go
@@ -66,3 +66,7 @@ func HasMatchingParentPath(ctx *gin.Context) bool {
 func SetTitle(ctx *gin.Context, title string) {
 	ctx.Header(ResponseHeaderTitle, title)
 }
+
+func SetIcon(ctx *gin.Context, iconHref string) {
+	ctx.Header(ResponseHeaderIcon, iconHref)
+}

--- a/pkg/htmx/gin.go
+++ b/pkg/htmx/gin.go
@@ -62,3 +62,7 @@ func HasMatchingParentPath(ctx *gin.Context) bool {
 	fmt.Println(shortCurrent, shortRequest)
 	return shortCurrent == shortRequest
 }
+
+func SetTitle(ctx *gin.Context, title string) {
+	ctx.Header(ResponseHeaderTitle, title)
+}

--- a/pkg/htmx/headers.go
+++ b/pkg/htmx/headers.go
@@ -52,4 +52,6 @@ const (
 const (
 	// ResponseHeaderTitle is associated with a custom htmx extension, "title-header", that intercepts this response header and updates the document's title to the new value when present.
 	ResponseHeaderTitle string = "Hx-Title"
+	// ResponseHeaderIcon
+	ResponseHeaderIcon string = "Hx-Icon"
 )

--- a/pkg/htmx/headers.go
+++ b/pkg/htmx/headers.go
@@ -47,3 +47,9 @@ const (
 	// ResponseHeaderTriggerAfterSwap allows you to trigger client side events, see the documentation for more info: https://htmx.org/headers/hx-trigger/
 	ResponseHeaderTriggerAfterSwap string = "Hx-Trigger-After-Swap"
 )
+
+// htmx custom extension headers
+const (
+	// ResponseHeaderTitle is associated with a custom htmx extension, "title-header", that intercepts this response header and updates the document's title to the new value when present.
+	ResponseHeaderTitle string = "Hx-Title"
+)

--- a/pkg/htmx/headers.go
+++ b/pkg/htmx/headers.go
@@ -52,6 +52,6 @@ const (
 const (
 	// ResponseHeaderTitle is associated with a custom htmx extension, "title-header", that intercepts this response header and updates the document's title to the new value when present.
 	ResponseHeaderTitle string = "Hx-Title"
-	// ResponseHeaderIcon
+	// ResponseHeaderIcon is associated with a custom htmx extension, "icon-header", that intercepts this response header and updates the document's icon link element when present.
 	ResponseHeaderIcon string = "Hx-Icon"
 )

--- a/web/templ/components/base/htmx.templ
+++ b/web/templ/components/base/htmx.templ
@@ -1,0 +1,11 @@
+package base
+
+script HtmxExtensionTitleHeader() {
+    htmx.defineExtension('title-header', {
+    onEvent : function(name, evt) {
+        if (name !== "htmx:afterRequest") return;
+        const hxTitle = evt.detail.xhr.getResponseHeader("Hx-Title");
+        if (hxTitle) window.document.title = hxTitle;
+    }
+  })
+}

--- a/web/templ/components/base/layout.templ
+++ b/web/templ/components/base/layout.templ
@@ -20,7 +20,7 @@ templ Layout(params LayoutParams) {
 		<head>
 			@Meta(params.PageTitle, params.CSSVersion)
 		</head>
-		<body class="h-full overflow-hidden dark:text-gray-300" hx-ext="title-header">
+		<body class="h-full overflow-hidden dark:text-gray-300" hx-ext="title-header,icon-header">
 			@Navbar(params.IsDarkMode)
 			@MainContentWithSidenav(params.Page) {
 				{ children... }

--- a/web/templ/components/base/layout.templ
+++ b/web/templ/components/base/layout.templ
@@ -20,7 +20,7 @@ templ Layout(params LayoutParams) {
 		<head>
 			@Meta(params.PageTitle, params.CSSVersion)
 		</head>
-		<body class="h-full overflow-hidden dark:text-gray-300">
+		<body class="h-full overflow-hidden dark:text-gray-300" hx-ext="title-header">
 			@Navbar(params.IsDarkMode)
 			@MainContentWithSidenav(params.Page) {
 				{ children... }

--- a/web/templ/components/base/meta.templ
+++ b/web/templ/components/base/meta.templ
@@ -12,8 +12,9 @@ templ Meta(pageTitle string, cssVersion string) {
 		name="description"
 		content="Imp is focused on building the premier small, business Inventory Management Product."
 	/>
-	<script defer src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
-	<script defer src="https://unpkg.com/htmx.org@1.9.10/dist/ext/loading-states.js" integrity="sha384-v04dReCP6N+wBCc+JjDUHyvkWJPO5jyzXxNdZHF/HZVyMXhh2USfi3UvCfiPwmmB" crossorigin="anonymous"></script>
+	<script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
+	// <script defer src="https://unpkg.com/htmx.org@1.9.10/dist/ext/loading-states.js" integrity="sha384-v04dReCP6N+wBCc+JjDUHyvkWJPO5jyzXxNdZHF/HZVyMXhh2USfi3UvCfiPwmmB" crossorigin="anonymous"></script>
+	@HtmxExtensionTitleHeader()
 	@sidenavScriptUtils()
 	<link rel="icon" type="image/x-icon" href="/static/favicon.ico"/>
 	<link rel="stylesheet" href={ fmt.Sprintf("/static/output.%s.css", cssVersion) }/>

--- a/web/templ/components/base/meta.templ
+++ b/web/templ/components/base/meta.templ
@@ -1,6 +1,7 @@
 package base
 
 import "fmt"
+import "dqix/web/templ/components/htmx"
 
 templ Meta(pageTitle string, cssVersion string) {
 	<meta charset="UTF-8"/>
@@ -14,7 +15,8 @@ templ Meta(pageTitle string, cssVersion string) {
 	/>
 	<script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
 	// <script defer src="https://unpkg.com/htmx.org@1.9.10/dist/ext/loading-states.js" integrity="sha384-v04dReCP6N+wBCc+JjDUHyvkWJPO5jyzXxNdZHF/HZVyMXhh2USfi3UvCfiPwmmB" crossorigin="anonymous"></script>
-	@HtmxExtensionTitleHeader()
+	@htmx.TitleHeader()
+	@htmx.IconHeader()
 	@sidenavScriptUtils()
 	<link rel="icon" type="image/x-icon" href="/static/favicon.ico"/>
 	<link rel="stylesheet" href={ fmt.Sprintf("/static/output.%s.css", cssVersion) }/>

--- a/web/templ/components/htmx/htmx.go
+++ b/web/templ/components/htmx/htmx.go
@@ -1,0 +1,1 @@
+package htmx

--- a/web/templ/components/htmx/icon-header.templ
+++ b/web/templ/components/htmx/icon-header.templ
@@ -1,0 +1,19 @@
+package htmx
+
+script IconHeader() {
+    htmx.defineExtension('icon-header', {
+        onEvent : function(name, evt) {
+            if (name !== "htmx:afterRequest") return;
+            const hxIcon = evt.detail.xhr.getResponseHeader("Hx-Icon");
+            if (hxIcon) {
+                var link = document.querySelector("link[rel='icon']");
+                if (!link) {
+                    link = document.createElement('link');
+                    link.rel = 'icon';
+                    document.head.appendChild(link);
+                }
+                link.href = hxIcon;
+            }
+        }
+    })
+}

--- a/web/templ/components/htmx/title-header.templ
+++ b/web/templ/components/htmx/title-header.templ
@@ -1,7 +1,7 @@
-package base
+package htmx
 
-script HtmxExtensionTitleHeader() {
-    htmx.defineExtension('title-header', {
+script TitleHeader() {
+  htmx.defineExtension('title-header', {
     onEvent : function(name, evt) {
         if (name !== "htmx:afterRequest") return;
         const hxTitle = evt.detail.xhr.getResponseHeader("Hx-Title");


### PR DESCRIPTION
# Overview
Created new custom htmx extension called `icon-header` that will watch AJAX request events and when a `Hx-Icon` response header is present will update the document's icon `<link>` element with the provided value.