### PR TITLE
Refactor Rendering Handlers and move Params structs

### DIFF
--- a/internal/router/inventory.go
+++ b/internal/router/inventory.go
@@ -37,7 +37,7 @@ func (a *app) InventoryClassificationWrapper(handler func(*gin.Context, params.I
 			SortPathGetter:  types.PrepareSimpleSortPath(*ctx.Request.URL),
 			SortOrderGetter: types.GetSortOrder(ctx.Request.URL),
 			LayoutParams: params.Layout{
-				PageTitle:  "DQIX | " + strings.Title(classification),
+				PageTitle:  strings.Title(classification),
 				Page:       classification,
 				IsDarkMode: gin_utils.IsDarkMode(ctx),
 				CSSVersion: a.cssVersion,
@@ -49,7 +49,7 @@ func (a *app) InventoryClassificationWrapper(handler func(*gin.Context, params.I
 }
 
 func InventoryClassificationRenderer(ctx *gin.Context, params params.InventoryClassification) {
-	htmx.SetTitle(ctx, params.LayoutParams.PageTitle)
+	htmx.SetTitle(ctx, params.LayoutParams.GetPageTitle())
 	htmx.SetIcon(ctx, params.LayoutParams.GetIconPath())
 
 	switch htmx.GetHxSwapTarget(ctx) {
@@ -82,7 +82,7 @@ func (a *app) InventoryWrapper(handler func(*gin.Context, params.Inventory)) fun
 			Inventory: inventory,
 			Getter:    a.data.GetQuickThing,
 			LayoutParams: params.Layout{
-				PageTitle:  "DQIX | " + inventory.Title,
+				PageTitle:  inventory.Title,
 				Page:       inventory.Classification,
 				IsDarkMode: gin_utils.IsDarkMode(ctx),
 				CSSVersion: a.cssVersion,
@@ -95,7 +95,7 @@ func (a *app) InventoryWrapper(handler func(*gin.Context, params.Inventory)) fun
 }
 
 func InventoryRenderer(ctx *gin.Context, params params.Inventory) {
-	htmx.SetTitle(ctx, params.LayoutParams.PageTitle)
+	htmx.SetTitle(ctx, params.LayoutParams.GetPageTitle())
 	htmx.SetIcon(ctx, params.LayoutParams.GetIconPath())
 
 	switch htmx.GetHxSwapTarget(ctx) {

--- a/internal/router/inventory.go
+++ b/internal/router/inventory.go
@@ -86,6 +86,7 @@ func (a *app) InventoryWrapper(handler func(*gin.Context, params.Inventory)) fun
 				Page:       inventory.Classification,
 				IsDarkMode: gin_utils.IsDarkMode(ctx),
 				CSSVersion: a.cssVersion,
+				IconPath:   inventory.ImageSrc(),
 			},
 		}
 
@@ -95,7 +96,7 @@ func (a *app) InventoryWrapper(handler func(*gin.Context, params.Inventory)) fun
 
 func InventoryRenderer(ctx *gin.Context, params params.Inventory) {
 	htmx.SetTitle(ctx, params.LayoutParams.PageTitle)
-	htmx.SetIcon(ctx, params.Inventory.ImageSrc())
+	htmx.SetIcon(ctx, params.LayoutParams.GetIconPath())
 
 	switch htmx.GetHxSwapTarget(ctx) {
 	case "page-content":

--- a/internal/router/inventory.go
+++ b/internal/router/inventory.go
@@ -2,9 +2,9 @@ package router
 
 import (
 	"dqix/internal/types"
+	"dqix/internal/types/params"
 	gin_utils "dqix/pkg/gin"
 	"dqix/pkg/htmx"
-	"dqix/web/templ/components/base"
 	"dqix/web/templ/pages"
 	"net/http"
 	"strings"
@@ -38,14 +38,14 @@ func (a *app) ClassificationHandler(ctx *gin.Context) {
 	pageTitle := "DQIX | " + strings.Title(classification)
 	htmx.SetTitle(ctx, pageTitle)
 	htmx.SetIcon(ctx, "/static/favicon.ico")
-	params := pages.InventoryClassificationParams{
+	params := params.InventoryClassification{
 		Classification:  classification,
 		Inventories:     inventories,
 		Stats:           inventories.GetHasInventoryStats(),
 		DisplayMode:     ctx.Query("display"),
 		SortPathGetter:  types.PrepareSimpleSortPath(*ctx.Request.URL),
 		SortOrderGetter: types.GetSortOrder(ctx.Request.URL),
-		LayoutParams: base.LayoutParams{
+		LayoutParams: params.Layout{
 			PageTitle:  pageTitle,
 			Page:       classification,
 			IsDarkMode: gin_utils.IsDarkMode(ctx),
@@ -87,10 +87,10 @@ func (a *app) InventoryHandler(ctx *gin.Context) {
 	pageTitle := "DQIX | " + inventory.Title
 	htmx.SetTitle(ctx, pageTitle)
 	htmx.SetIcon(ctx, inventory.ImageSrc())
-	params := pages.InventoryParams{
+	params := params.Inventory{
 		Inventory: inventory,
 		Getter:    a.data.GetQuickThing,
-		LayoutParams: base.LayoutParams{
+		LayoutParams: params.Layout{
 			PageTitle:  pageTitle,
 			Page:       inventory.Classification,
 			IsDarkMode: gin_utils.IsDarkMode(ctx),

--- a/internal/router/monsters.go
+++ b/internal/router/monsters.go
@@ -6,6 +6,7 @@ import (
 	gin_utils "dqix/pkg/gin"
 	"dqix/pkg/htmx"
 	"dqix/web/templ/pages"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -32,7 +33,7 @@ func (a *app) MonsterFamilyWrapper(handler func(*gin.Context, params.MonsterFami
 			SortPathGetter:  types.PrepareSimpleSortPath(*ctx.Request.URL),
 			SortOrderGetter: types.GetSortOrder(ctx.Request.URL),
 			LayoutParams: params.Layout{
-				PageTitle:  "DQIX | " + types.ToFamilyTitle(familyId) + " Family",
+				PageTitle:  fmt.Sprintf("%s Family", types.ToFamilyTitle(familyId)),
 				Page:       familyId,
 				IsDarkMode: gin_utils.IsDarkMode(ctx),
 				CSSVersion: a.cssVersion,
@@ -44,7 +45,7 @@ func (a *app) MonsterFamilyWrapper(handler func(*gin.Context, params.MonsterFami
 }
 
 func MonsterFamilyRenderer(ctx *gin.Context, params params.MonsterFamily) {
-	htmx.SetTitle(ctx, params.LayoutParams.PageTitle)
+	htmx.SetTitle(ctx, params.LayoutParams.GetPageTitle())
 	htmx.SetIcon(ctx, params.LayoutParams.GetIconPath())
 
 	switch htmx.GetHxSwapTarget(ctx) {
@@ -75,7 +76,7 @@ func (a *app) MonsterWrapper(handler func(*gin.Context, params.Monster)) func(*g
 			Monster: monster,
 			Getter:  a.data.GetQuickThing,
 			LayoutParams: params.Layout{
-				PageTitle:  "DQIX | " + monster.Title,
+				PageTitle:  monster.Title,
 				Page:       monster.GetFamilyID(),
 				IsDarkMode: gin_utils.IsDarkMode(ctx),
 				CSSVersion: a.cssVersion,
@@ -87,7 +88,7 @@ func (a *app) MonsterWrapper(handler func(*gin.Context, params.Monster)) func(*g
 }
 
 func MonsterRenderer(ctx *gin.Context, params params.Monster) {
-	htmx.SetTitle(ctx, params.LayoutParams.PageTitle)
+	htmx.SetTitle(ctx, params.LayoutParams.GetPageTitle())
 	htmx.SetIcon(ctx, params.LayoutParams.GetIconPath())
 
 	switch htmx.GetHxSwapTarget(ctx) {

--- a/internal/router/monsters.go
+++ b/internal/router/monsters.go
@@ -2,9 +2,9 @@ package router
 
 import (
 	"dqix/internal/types"
+	"dqix/internal/types/params"
 	gin_utils "dqix/pkg/gin"
 	"dqix/pkg/htmx"
-	"dqix/web/templ/components/base"
 	"dqix/web/templ/pages"
 	"net/http"
 
@@ -27,14 +27,14 @@ func (a *app) MonsterFamilyHandler(ctx *gin.Context) {
 	pageTitle := "DQIX | " + types.ToFamilyTitle(familyId) + " Family"
 	htmx.SetTitle(ctx, pageTitle)
 	htmx.SetIcon(ctx, "/static/favicon.ico")
-	params := pages.MonsterFamilyParams{
+	params := params.MonsterFamily{
 		Family:          familyId,
 		FamilyTitle:     types.ToFamilyTitle(familyId),
 		Monsters:        monsters,
 		DisplayMode:     ctx.Query("display"),
 		SortPathGetter:  types.PrepareSimpleSortPath(*ctx.Request.URL),
 		SortOrderGetter: types.GetSortOrder(ctx.Request.URL),
-		LayoutParams: base.LayoutParams{
+		LayoutParams: params.Layout{
 			PageTitle:  pageTitle,
 			Page:       familyId,
 			IsDarkMode: gin_utils.IsDarkMode(ctx),
@@ -68,10 +68,10 @@ func (a *app) MonsterHandler(ctx *gin.Context) {
 	pageTitle := "DQIX | " + monster.Title
 	htmx.SetTitle(ctx, pageTitle)
 	htmx.SetIcon(ctx, "/static/favicon.ico") // htmx.SetIcon(ctx, inventory.ImageSrc())
-	params := pages.MonsterParams{
+	params := params.Monster{
 		Monster: monster,
 		Getter:  a.data.GetQuickThing,
-		LayoutParams: base.LayoutParams{
+		LayoutParams: params.Layout{
 			PageTitle:  pageTitle,
 			Page:       monster.GetFamilyID(),
 			IsDarkMode: gin_utils.IsDarkMode(ctx),

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -41,7 +41,6 @@ func (a *app) SetupRouter() *gin.Engine {
 	engine.GET("/", func(ctx *gin.Context) {
 		params := params.Index{
 			LayoutParams: params.Layout{
-				PageTitle:  "Dragon Quest IX",
 				IsDarkMode: gin_utils.IsDarkMode(ctx),
 				CSSVersion: a.cssVersion,
 			},

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,8 +1,8 @@
 package router
 
 import (
+	"dqix/internal/types/params"
 	gin_utils "dqix/pkg/gin"
-	"dqix/web/templ/components/base"
 	"dqix/web/templ/pages"
 	"fmt"
 	"net/http"
@@ -39,8 +39,8 @@ func (a *app) SetupRouter() *gin.Engine {
 	a.StaticFiles(engine)
 
 	engine.GET("/", func(ctx *gin.Context) {
-		params := pages.IndexParams{
-			LayoutParams: base.LayoutParams{
+		params := params.Index{
+			LayoutParams: params.Layout{
 				PageTitle:  "Dragon Quest IX",
 				IsDarkMode: gin_utils.IsDarkMode(ctx),
 				CSSVersion: a.cssVersion,

--- a/internal/types/params/inventory.go
+++ b/internal/types/params/inventory.go
@@ -1,0 +1,23 @@
+package params
+
+import (
+	"dqix/internal/types"
+
+	"github.com/a-h/templ"
+)
+
+type InventoryClassification struct {
+	Classification  string
+	Inventories     types.InventorySlice
+	Stats           types.HasInventoryStats
+	DisplayMode     string
+	LayoutParams    Layout
+	SortPathGetter  func(sortField string) templ.SafeURL
+	SortOrderGetter func(sortField string) string
+}
+
+type Inventory struct {
+	Inventory    types.Inventory
+	Getter       types.IGetThingFromID
+	LayoutParams Layout
+}

--- a/internal/types/params/layout.go
+++ b/internal/types/params/layout.go
@@ -5,6 +5,16 @@ type Layout struct {
 	Page       string
 	IsDarkMode bool
 	CSSVersion string
+	IconPath   string
+}
+
+// GetIconPath returns the IconPath when it not empty, otherwise will return the default path to the app's favicon.
+func (l Layout) GetIconPath() string {
+	if l.IconPath != "" {
+		return l.IconPath
+	}
+
+	return "/static/favicon.ico"
 }
 
 type Index struct {

--- a/internal/types/params/layout.go
+++ b/internal/types/params/layout.go
@@ -1,5 +1,7 @@
 package params
 
+import "fmt"
+
 type Layout struct {
 	PageTitle  string
 	Page       string
@@ -8,13 +10,22 @@ type Layout struct {
 	IconPath   string
 }
 
-// GetIconPath returns the IconPath when it not empty, otherwise will return the default path to the app's favicon.
-func (l Layout) GetIconPath() string {
-	if l.IconPath != "" {
-		return l.IconPath
+// GetPageTitle returns the formatted PageTitle when not empty, otherwise will return the default page title.
+func (l Layout) GetPageTitle() string {
+	if l.PageTitle == "" {
+		return "Dragon Quest IX"
 	}
 
-	return "/static/favicon.ico"
+	return fmt.Sprintf("DQIX | %s", l.PageTitle)
+}
+
+// GetIconPath returns the IconPath when not empty, otherwise will return the default path to the app's favicon.
+func (l Layout) GetIconPath() string {
+	if l.IconPath == "" {
+		return "/static/favicon.ico"
+	}
+
+	return l.IconPath
 }
 
 type Index struct {

--- a/internal/types/params/layout.go
+++ b/internal/types/params/layout.go
@@ -1,0 +1,12 @@
+package params
+
+type Layout struct {
+	PageTitle  string
+	Page       string
+	IsDarkMode bool
+	CSSVersion string
+}
+
+type Index struct {
+	LayoutParams Layout
+}

--- a/internal/types/params/monsters.go
+++ b/internal/types/params/monsters.go
@@ -1,0 +1,23 @@
+package params
+
+import (
+	"dqix/internal/types"
+
+	"github.com/a-h/templ"
+)
+
+type MonsterFamily struct {
+	Family          string
+	FamilyTitle     string
+	Monsters        types.MonsterSlice
+	DisplayMode     string
+	LayoutParams    Layout
+	SortPathGetter  func(sortField string) templ.SafeURL
+	SortOrderGetter func(sortField string) string
+}
+
+type Monster struct {
+	Monster      types.Monster
+	Getter       types.IGetThingFromID
+	LayoutParams Layout
+}

--- a/web/templ/components/base/layout.templ
+++ b/web/templ/components/base/layout.templ
@@ -1,15 +1,9 @@
 package base
 
 import "dqix/web/templ/components/buttons"
+import "dqix/internal/types/params"
 
-type LayoutParams struct {
-	PageTitle  string
-	Page       string
-	IsDarkMode bool
-	CSSVersion string
-}
-
-templ Layout(params LayoutParams) {
+templ Layout(params params.Layout) {
 	<!DOCTYPE html>
 	<html
 		lang="en"

--- a/web/templ/components/base/layout.templ
+++ b/web/templ/components/base/layout.templ
@@ -13,7 +13,7 @@ templ Layout(params params.Layout) {
 		}
 	>
 		<head>
-			@Meta(params.PageTitle, params.CSSVersion)
+			@Meta(params)
 		</head>
 		<body class="h-full overflow-hidden dark:text-gray-300" hx-ext="title-header,icon-header">
 			@Navbar(params.IsDarkMode)

--- a/web/templ/components/base/meta.templ
+++ b/web/templ/components/base/meta.templ
@@ -2,8 +2,9 @@ package base
 
 import "fmt"
 import "dqix/web/templ/components/htmx"
+import "dqix/internal/types/params"
 
-templ Meta(pageTitle string, cssVersion string) {
+templ Meta(params params.Layout) {
 	<meta charset="UTF-8"/>
 	<meta
 		name="viewport"
@@ -18,9 +19,9 @@ templ Meta(pageTitle string, cssVersion string) {
 	@htmx.TitleHeader()
 	@htmx.IconHeader()
 	@sidenavScriptUtils()
-	<link rel="icon" type="image/x-icon" href="/static/favicon.ico"/>
-	<link rel="stylesheet" href={ fmt.Sprintf("/static/output.%s.css", cssVersion) }/>
+	<link rel="icon" type="image/x-icon" href={ params.GetIconPath() }/>
+	<link rel="stylesheet" href={ fmt.Sprintf("/static/output.%s.css", params.CSSVersion) }/>
 	<title>
-		{ pageTitle }
+		{ params.PageTitle }
 	</title>
 }

--- a/web/templ/components/base/meta.templ
+++ b/web/templ/components/base/meta.templ
@@ -22,6 +22,6 @@ templ Meta(params params.Layout) {
 	<link rel="icon" type="image/x-icon" href={ params.GetIconPath() }/>
 	<link rel="stylesheet" href={ fmt.Sprintf("/static/output.%s.css", params.CSSVersion) }/>
 	<title>
-		{ params.PageTitle }
+		{ params.GetPageTitle() }
 	</title>
 }

--- a/web/templ/pages/index.templ
+++ b/web/templ/pages/index.templ
@@ -1,12 +1,9 @@
 package pages
 
 import "dqix/web/templ/components/base"
+import "dqix/internal/types/params"
 
-type IndexParams struct {
-	LayoutParams base.LayoutParams
-}
-
-templ IndexPage(params IndexParams) {
+templ IndexPage(params params.Index) {
 	@base.Layout(params.LayoutParams) {
 		@indexContent()
 	}

--- a/web/templ/pages/inventory-classifications.templ
+++ b/web/templ/pages/inventory-classifications.templ
@@ -7,31 +7,21 @@ import "strings"
 import "dqix/web/templ/utilities"
 import "strconv"
 import "fmt"
+import "dqix/internal/types/params"
 
-// Inventory Classifications
-type InventoryClassificationParams struct {
-	Classification  string
-	Inventories     types.InventorySlice
-	Stats           types.HasInventoryStats
-	DisplayMode     string
-	LayoutParams    base.LayoutParams
-	SortPathGetter  func(sortField string) templ.SafeURL
-	SortOrderGetter func(sortField string) string
-}
-
-templ InventoryClassificationPage(params InventoryClassificationParams) {
+templ InventoryClassificationPage(params params.InventoryClassification) {
 	@base.Layout(params.LayoutParams) {
 		@InventoryClassificationContent(params)
 	}
 }
 
-templ InventoryClassificationContentWithSideNav(params InventoryClassificationParams) {
+templ InventoryClassificationContentWithSideNav(params params.InventoryClassification) {
 	@base.MainContentWithSidenav(params.Classification) {
 		@InventoryClassificationContent(params)
 	}
 }
 
-templ InventoryClassificationContent(params InventoryClassificationParams) {
+templ InventoryClassificationContent(params params.InventoryClassification) {
 	<h1 class="text-3xl font-bold">{ strings.Title(strings.ReplaceAll(params.Classification, "-", " ")) }</h1>
 	if params.DisplayMode == "list" {
 		@InventoryClassificationList(params.Inventories)
@@ -40,7 +30,7 @@ templ InventoryClassificationContent(params InventoryClassificationParams) {
 	}
 }
 
-templ InventoryClassificationTable(params InventoryClassificationParams) {
+templ InventoryClassificationTable(params params.InventoryClassification) {
 	<table role="table" id="inventory-table">
 		<thead role="rowgroup" hx-boost="true" hx-target="#inventory-table" hx-swap="outerHTML">
 			@inventoryTableHeader(params)
@@ -53,7 +43,7 @@ templ InventoryClassificationTable(params InventoryClassificationParams) {
 	</table>
 }
 
-templ inventoryTableHeader(params InventoryClassificationParams) {
+templ inventoryTableHeader(params params.InventoryClassification) {
 	<tr role="row" class="[&>th]:py-2 [&>th]:pr-4 [&>th:not(.text-left)]:pl-4">
 		@SortableColumnHeaderLeft(params, "name", "Name")
 		<th role="columnheader" scope="col" id="image"></th>
@@ -197,15 +187,15 @@ templ inventoryTableRow(inventory types.Inventory, stats types.HasInventoryStats
 	</tr>
 }
 
-func SortableColumnHeaderLeft(params InventoryClassificationParams, id string, label string) templ.Component {
+func SortableColumnHeaderLeft(params params.InventoryClassification, id string, label string) templ.Component {
 	return sortableColumnHeader(params, id, label, templ.Attributes{"class": "group relative text-left"})
 }
 
-func SortableColumnHeader(params InventoryClassificationParams, id string, label string) templ.Component {
+func SortableColumnHeader(params params.InventoryClassification, id string, label string) templ.Component {
 	return sortableColumnHeader(params, id, label, templ.Attributes{"class": "group relative"})
 }
 
-templ sortableColumnHeader(params InventoryClassificationParams, id string, label string, attrs templ.Attributes) {
+templ sortableColumnHeader(params params.InventoryClassification, id string, label string, attrs templ.Attributes) {
 	<th
 		role="columnheader"
 		scope="col"
@@ -219,7 +209,7 @@ templ sortableColumnHeader(params InventoryClassificationParams, id string, labe
 	</th>
 }
 
-templ SortableColumnHeaderLink(params InventoryClassificationParams, id string, label string) {
+templ SortableColumnHeaderLink(params params.InventoryClassification, id string, label string) {
 	<a
 		href={ params.SortPathGetter(id) }
 		class="after:hidden group-aria-[sort=descending]:after:inline group-aria-[sort=ascending]:after:inline 

--- a/web/templ/pages/inventory.templ
+++ b/web/templ/pages/inventory.templ
@@ -6,28 +6,22 @@ import "dqix/web/templ/components/links"
 import "strings"
 import "strconv"
 import "fmt"
+import "dqix/internal/types/params"
 
 // Inventory
-
-type InventoryParams struct {
-	Inventory    types.Inventory
-	Getter       types.IGetThingFromID
-	LayoutParams base.LayoutParams
-}
-
-templ InventoryPage(params InventoryParams) {
+templ InventoryPage(params params.Inventory) {
 	@base.Layout(params.LayoutParams) {
 		@InventoryContent(params)
 	}
 }
 
-templ InventoryContentWithSideNav(params InventoryParams) {
+templ InventoryContentWithSideNav(params params.Inventory) {
 	@base.MainContentWithSidenav(params.Inventory.Classification) {
 		@InventoryContent(params)
 	}
 }
 
-templ InventoryContent(params InventoryParams) {
+templ InventoryContent(params params.Inventory) {
 	<div hx-boost="true" hx-target="#page-content">
 		<div class="flex flex-row items-center">
 			<img src={ params.Inventory.ImageSrc() } alt={ params.Inventory.GetID() }/>

--- a/web/templ/pages/monster-family.templ
+++ b/web/templ/pages/monster-family.templ
@@ -4,30 +4,21 @@ import "dqix/web/templ/components/base"
 import "dqix/internal/types"
 import "dqix/web/templ/components/links"
 import "dqix/web/templ/utilities"
+import "dqix/internal/types/params"
 
-type MonsterFamilyParams struct {
-	Family          string
-	FamilyTitle     string
-	Monsters        types.MonsterSlice
-	DisplayMode     string
-	LayoutParams    base.LayoutParams
-	SortPathGetter  func(sortField string) templ.SafeURL
-	SortOrderGetter func(sortField string) string
-}
-
-templ MonsterFamilyPage(params MonsterFamilyParams) {
+templ MonsterFamilyPage(params params.MonsterFamily) {
 	@base.Layout(params.LayoutParams) {
 		@MonsterFamilyContent(params)
 	}
 }
 
-templ MonsterFamilyContentWithSideNav(params MonsterFamilyParams) {
+templ MonsterFamilyContentWithSideNav(params params.MonsterFamily) {
 	@base.MainContentWithSidenav(params.Family) {
 		@MonsterFamilyContent(params)
 	}
 }
 
-templ MonsterFamilyContent(params MonsterFamilyParams) {
+templ MonsterFamilyContent(params params.MonsterFamily) {
 	<h1 class="text-3xl font-bold">{ params.FamilyTitle + " Family" }</h1>
 	@MonsterFamilyList(params.Monsters)
 }

--- a/web/templ/pages/monster.templ
+++ b/web/templ/pages/monster.templ
@@ -1,26 +1,20 @@
 package pages
 
-import "dqix/internal/types"
 import "dqix/web/templ/components/base"
+import "dqix/internal/types/params"
 
-type MonsterParams struct {
-	Monster      types.Monster
-	Getter       types.IGetThingFromID
-	LayoutParams base.LayoutParams
-}
-
-templ MonsterPage(params MonsterParams) {
+templ MonsterPage(params params.Monster) {
 	@base.Layout(params.LayoutParams) {
 		@MonsterContent(params)
 	}
 }
 
-templ MonsterContentWithSideNav(params MonsterParams) {
+templ MonsterContentWithSideNav(params params.Monster) {
 	@base.MainContentWithSidenav(params.Monster.GetFamilyID()) {
 		@MonsterContent(params)
 	}
 }
 
-templ MonsterContent(params MonsterParams) {
+templ MonsterContent(params params.Monster) {
 	<div hx-boost="true" hx-target="#page-content"><h1>{ params.Monster.Title }</h1></div>
 }


### PR DESCRIPTION
# Overview
I plan to support all data retrieval paths with an API equivalent that returns the data in the requested format. To make this simpler, I changed the model to have a wrapper function that parses data from `*gin.Context` and prepares a respective params struct. This function takes in a handler and will call the handler at the end of execution with the context and prepared params. Currently, the only handler functions available are the renderers and these handle all of the htmx conditional rendering and response header setting. Eventually, I will come back through and create an API equivalent of these renderer functions and add `/api` routes for them. 

Additionally, to make it clearer that the params structs are not solely used for templ page rendering, I moved all of them into a new `params` package.