### PR TITLE
TextBlockLinks Component

### DIFF
--- a/data/wikidot/raw.json
+++ b/data/wikidot/raw.json
@@ -8512,7 +8512,7 @@
     "Path": "baramos",
     "Text": [
       "Baramos",
-      "Windproof king and wizard who wastes no time whipping out Kaboom, Kafrizz and all kinds of calamity-inducing conjury.",
+      "Windproof king and wizard who wastes no time whipping out ${Kaboom}, ${Kafrizz} and all kinds of calamity-inducing conjury.",
       "Takes great pleasure in obliterating people while they're busy poking fun at his bizarre appearance.",
       "Exp.:",
       "59600",
@@ -12050,7 +12050,7 @@
     "Text": [
       "022 Brownie",
       "Erratic enemies that can attain an instant state of high tension, only to topple over and go off the boil.",
-      "Bodkin bowyers often take them on camping trips and trick them into tapping in their tent pegs for them.",
+      "${Bodkin bowyer}s often take them on camping trips and trick them into tapping in their tent pegs for them.",
       "Exp.:",
       "56",
       "Gold:",
@@ -38879,7 +38879,7 @@
     "Path": "nod-s-tear",
     "Text": [
       "Nod's Tear",
-      "A teardrop shed by noble Nodoph.",
+      "A teardrop shed by noble ${Nodoph}.",
       "Rarity:",
       "1/5",
       "Classification:",
@@ -38897,13 +38897,15 @@
   "/nodoph": {
     "Path": "nodoph",
     "Text": [
-      "Nodoph",
+      "278 Nodoph",
       "Sleeps atop the tower of Nod. Lost his powers three hundred years ago when he and Celestria went to Gittingham Palace.",
       "Created by the Grand Architect Zenus to destroy mortalkind, but had his hatred for humanity soothed by Serena.",
       "Exp.:",
       "46800",
       "Gold:",
       "5120",
+      "Family:",
+      "??? family",
       "Items dropped:",
       "Dragon scale",
       "Where to find:",

--- a/web/data/inventory/bag/items/important.json
+++ b/web/data/inventory/bag/items/important.json
@@ -763,7 +763,7 @@
  },
  "nod-s-tear": {
   "title": "Nod's Tear",
-  "description": "A teardrop shed by noble Nodoph.",
+  "description": "A teardrop shed by noble ${Nodoph}.",
   "statistics": {
    "special": {}
   },

--- a/web/data/monsters/humanoid.json
+++ b/web/data/monsters/humanoid.json
@@ -61,7 +61,7 @@
   "number": 22,
   "title": "Brownie",
   "description": "Erratic enemies that can attain an instant state of high tension, only to topple over and go off the boil.",
-  "secondaryDescription": "Bodkin bowyers often take them on camping trips and trick them into tapping in their tent pegs for them.",
+  "secondaryDescription": "${Bodkin bowyer}s often take them on camping trips and trick them into tapping in their tent pegs for them.",
   "experience": 56,
   "goldDropped": 40,
   "family": "Humanoid",

--- a/web/data/monsters/unknown.json
+++ b/web/data/monsters/unknown.json
@@ -1,7 +1,7 @@
 {
  "baramos": {
   "title": "Baramos",
-  "description": "Windproof king and wizard who wastes no time whipping out Kaboom, Kafrizz and all kinds of calamity-inducing conjury.",
+  "description": "Windproof king and wizard who wastes no time whipping out ${Kaboom}, ${Kafrizz} and all kinds of calamity-inducing conjury.",
   "secondaryDescription": "Takes great pleasure in obliterating people while they're busy poking fun at his bizarre appearance.",
   "experience": 59600,
   "goldDropped": 2490,
@@ -142,6 +142,22 @@
   "battleInfo": {
    "elementalAversions": "Wind (1.5x damage)"
   }
+ },
+ "nodoph": {
+  "number": 278,
+  "title": "Nodoph",
+  "description": "Sleeps atop the tower of Nod. Lost his powers three hundred years ago when he and Celestria went to Gittingham Palace.",
+  "secondaryDescription": "Created by the Grand Architect Zenus to destroy mortalkind, but had his hatred for humanity soothed by Serena.",
+  "experience": 46800,
+  "goldDropped": 5120,
+  "family": "unknown",
+  "whereToFind": [
+   "Tower of Nod (During"
+  ],
+  "itemsDropped": {
+   "dragon-scale": "Where to find:"
+  },
+  "battleInfo": {}
  },
  "nokturnus": {
   "title": "Nokturnus",

--- a/web/templ/components/links/text-block-links.templ
+++ b/web/templ/components/links/text-block-links.templ
@@ -2,7 +2,6 @@ package links
 
 import "dqix/internal/types"
 import "regexp"
-import "fmt"
 
 type iText interface {
 	render() templ.Component

--- a/web/templ/components/links/text-block-links.templ
+++ b/web/templ/components/links/text-block-links.templ
@@ -1,0 +1,68 @@
+package links
+
+import "dqix/internal/types"
+import "regexp"
+import "fmt"
+
+type iText interface {
+	render() templ.Component
+}
+
+type textBlockLinks []iText
+
+type spanBlock struct {
+	text string
+}
+
+func (s spanBlock) render() templ.Component {
+	return span(s.text)
+}
+
+templ span(text string) {
+	<span>{ text }</span>
+}
+
+type thinkLinkBlock struct {
+	id     string
+	getter types.IGetThingFromID
+}
+
+func (t thinkLinkBlock) render() templ.Component {
+	return ThingLink(t.id, t.getter)
+}
+
+func parseTextBlockLinks(text string, getter types.IGetThingFromID) (blocks textBlockLinks) {
+	rgxp := regexp.MustCompile(`\${[^}]+}`)
+
+	indices := rgxp.FindAllIndex([]byte(text), len(text))
+	if len(indices) == 0 {
+		blocks = append(blocks, spanBlock{text: text})
+		return
+	}
+
+	currentIndex := 0
+	for _, index := range indices {
+		section := text[currentIndex:index[0]]
+		if section != "" {
+			blocks = append(blocks, spanBlock{text: section})
+		}
+
+		thingId := types.TitleToID(text[index[0]+2 : index[1]-1])
+		blocks = append(blocks, thinkLinkBlock{id: thingId, getter: getter})
+
+		currentIndex = index[1]
+	}
+
+	endSection := text[indices[len(indices)-1][1]:]
+	if endSection != "" {
+		blocks = append(blocks, spanBlock{text: endSection})
+	}
+
+	return
+}
+
+templ TextBlockLinks(text string, getter types.IGetThingFromID) {
+	for _, textBlockLink := range parseTextBlockLinks(text, getter) {
+		@textBlockLink.render()
+	}
+}

--- a/web/templ/pages/inventory.templ
+++ b/web/templ/pages/inventory.templ
@@ -30,7 +30,9 @@ templ InventoryContent(params params.Inventory) {
 			</h1>
 		</div>
 		<hr/>
-		<p id="description" class="pt-4 pb-2">{ params.Inventory.Description }</p>
+		<p id="description" class="pt-4 pb-2">
+			@links.TextBlockLinks(params.Inventory.Description, params.Getter)
+		</p>
 		if params.Inventory.Statistics != (types.Statistics{}) {
 			<p id="statistics" class="py-2">
 				if params.Inventory.Statistics.Attack > 0 {

--- a/web/templ/pages/monster.templ
+++ b/web/templ/pages/monster.templ
@@ -28,10 +28,10 @@ templ MonsterContent(params params.Monster) {
 		</div>
 		<hr/>
 		<p id="description" class="pt-4 pb-2">
-			{ params.Monster.Description }
+			@links.TextBlockLinks(params.Monster.Description, params.Getter)
 			if params.Monster.SecondaryDescription != "" {
 				<br/>
-				{ params.Monster.SecondaryDescription }
+				@links.TextBlockLinks(params.Monster.SecondaryDescription, params.Getter)
 			}
 		</p>
 		<p id="information" class="py-2">


### PR DESCRIPTION
# Overview
Added a new `TextBlockLinks` component that will parse a given text block for strings wrapped in `${ }` and use them as IDs to render them as `ThingLink`s. Non-ID text will be rendered as spans.